### PR TITLE
Save the game before making a save state, for convenience

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -181,6 +181,16 @@ function global.handleKeys(controller, key, dt)
     for i, v in ipairs(saveStateKeys) do
         if key == v and love.keyboard.isDown("z") then
             if G.STAGE == G.STAGES.RUN then
+                if not (
+                    G.STATE == G.STATES.TAROT_PACK
+                    or G.STATE == G.STATES.PLANET_PACK
+                    or G.STATE == G.STATES.SPECTRAL_PACK
+                    or G.STATE == G.STATES.STANDARD_PACK
+                    or G.STATE == G.STATES.BUFFOON_PACK
+                    or G.STATE == G.STATES.SMODS_BOOSTER_OPENED
+                ) then
+                    save_run()
+                end
                 compress_and_save(G.SETTINGS.profile .. '/' .. 'debugsave' .. v .. '.jkr', G.ARGS.save_run)
                 log("Saved to slot", v)
             end


### PR DESCRIPTION
Saves the game before making a save state, so if you create some jokers and make a save state, you don't have to create those again. This has saved a lot of time in testing.

The check for if it's safe to save is a bit fragile, discussion is welcome