### PR TITLE
Add joker slot button

### DIFF
--- a/debugplus/core.lua
+++ b/debugplus/core.lua
@@ -399,6 +399,12 @@ function global.registerButtons()
             add_tag(Tag('tag_double', false, 'Big'))
         end
     end
+    G.FUNCS.DT_add_joker_slot = function()
+        if G.STAGE == G.STAGES.RUN and G.jokers then
+            G.jokers.config.card_limit = G.jokers.config.card_limit + 1
+            logger.log("Added joker slot. New limit:", G.jokers.config.card_limit)
+        end
+    end
 end
 
 function global.togglePerfUI()

--- a/lovely/debug-enhancements.toml
+++ b/lovely/debug-enhancements.toml
@@ -67,6 +67,7 @@ position = "after"
 payload = '''
 UIBox_button{ label = {"Win Blind"}, button = "DT_win_blind", minw = 1.7, minh = 0.4, scale = 0.35},
 UIBox_button{ label = {"Double Tag"}, button = "DT_double_tag", minw = 1.7, minh = 0.4, scale = 0.35},
+UIBox_button{ label = {"+ Joker Slot"}, button = "DT_add_joker_slot", minw = 1.7, minh = 0.4, scale = 0.35},
 '''
 match_indent = true
 overwrite = false


### PR DESCRIPTION
## Description
This PR adds one new button to the debug tools menu:

* `+ Joker Slot`: Increases the joker slot limit by 1

## Changes

* Added new functions in debugplus/core.lua to handle joker slot management
* Added new buttons in the debug tools UI via lovely/debug-enhancements.toml
* Used existing logger functionality to print confirmation messages

## Testing
I've tested this functionality with:

* New and existing runs
* Verifying the joker slot count changes visually
* Checking that the functions prevent reducing slots below 1
* Ensuring the logger displays appropriate messages

## Screenshot

![image](https://github.com/user-attachments/assets/a65a3c35-bfd2-4395-853b-eae2573960bd)
