### PR TITLE
feat: added "advanced" to the result of api.createLogger

### DIFF
--- a/debugplus/api.lua
+++ b/debugplus/api.lua
@@ -23,7 +23,8 @@ local function createLogger(name)
         debug = logger.createLogFn(name, "DEBUG"),
         info = logger.createLogFn(name, "INFO"),
         warn = logger.createLogFn(name, "WARN"),
-        error = logger.createLogFn(name, "ERROR"),  
+        error = logger.createLogFn(name, "ERROR"),
+        advanced = logger.handleLogAdvanced
     }
 end
 


### PR DESCRIPTION
Simple change to expose `logger.handleLogAdvanced` for devs that have use for it, though I'd understand if this went against your design philosophy.
My use case was displaying non-standard colors at a time other than a command completing. Maybe there's already a way to do this that I missed?

![image](https://github.com/user-attachments/assets/5feab8f5-3535-4558-9fd0-ebf68f1aa129)
