### PR TITLE
feat: Add gamestate command for save/load functionality

### DIFF
--- a/debugplus/console.lua
+++ b/debugplus/console.lua
@@ -395,6 +395,63 @@ commands = {{
             return "This command only works while hovering over a card. Rerun it while hovering over a card.", "ERROR"
         end
     end
+}, {
+    name = "gamestate",
+    source = "debugplus",
+    shortDesc = "Save, load, or list game states",
+    desc = "Save, load, or list game states.\nUsage:\ngamestate save <name> - Saves current game state to <name>.jkr\ngamestate load <name> - Loads game state from <name>.jkr\ngamestate list - Lists all available game state files\n\nExample:\ngamestate save after_boss1\ngamestate load after_boss1\ngamestate list",
+    exec = function(args, rawArgs, dp)
+        local core = require("debugplus.core")
+
+        if not args[1] then
+            return "Usage: gamestate <save|load|list> [name]", "ERROR"
+        end
+
+        local action = string.lower(args[1])
+
+        if action == "list" then
+            local game_states = core.listGameStates()
+            if #game_states == 0 then
+                return "No game state files found"
+            end
+
+            local output = "Available game states:"
+            for _, state in ipairs(game_states) do
+                output = output .. "\n" .. state.name .. ": " .. state.path
+            end
+            return output
+        end
+
+        local name = args[2]
+        if not name then
+            return "Please provide a name for the game state", "ERROR"
+        end
+
+        -- Validate name (alphanumeric, dash, underscore only)
+        if not string.match(name, "^[a-zA-Z0-9_-]+$") then
+            return "Game state name can only contain letters, numbers, dashes, and underscores", "ERROR"
+        end
+
+        local filename = name .. ".jkr"
+
+        if action == "save" then
+            local success, message, filepath = core.saveGameState(filename)
+            if success then
+                return "Saved game state to: " .. filepath
+            else
+                return "Failed to save: " .. message, "ERROR"
+            end
+        elseif action == "load" then
+            local success, message, filepath = core.loadGameState(filename)
+            if success then
+                return "Loaded game state from: " .. filepath
+            else
+                return "Failed to load: " .. message, "ERROR"
+            end
+        else
+            return "Invalid action. Use 'save', 'load', or 'list'", "ERROR"
+        end
+    end
 }}
 local input = ui.TextInput.new(0)
 


### PR DESCRIPTION
## Summary

Adds a new `gamestate` console command that provides convenient save state management during gameplay. This allows players to save snapshots of their run at any point and load them back later, which is invaluable for debugging, testing specific scenarios, and experimenting with game mechanics.

## Motivation

When debugging or developing mods, it's often necessary to test specific game states repeatedly. Previously, this required either:
- Playing through the entire run to reach the desired state each time
- Manually managing `.jkr` save files in the file system

This feature streamlines the workflow by providing an in-game interface for save state management.

## Usage

### Save a Game State

```
gamestate save <name>
```

Saves the current game state to `<name>.jkr` in your profile directory.

**Example:**
```
gamestate save after_boss1
gamestate save pre_final_boss
gamestate save interesting_seed
```

**Restrictions:**
- Can only save during an active run (not in menus)
- Cannot save while opening booster packs

### Load a Game State

```
gamestate load <name>
```

Loads a previously saved game state from `<name>.jkr`.

**Example:**
```
gamestate load after_boss1
```

**Note:** This will delete your current run and replace it with the loaded state.

### List Available Game States

```
gamestate list
```

Displays all available `.jkr` files in your profile directory with their full paths.

**Example output:**
```
Available game states:
after_boss1: /Users/player/Library/Application Support/Balatro/1/after_boss1.jkr
pre_final_boss: /Users/player/Library/Application Support/Balatro/1/pre_final_boss.jkr
```

## Technical Details

### Implementation

- **Core functions** (`debugplus/core.lua`):
  - `saveGameState(filename)` - Uses Balatro's native `save_run()` and `compress_and_save()` functions
  - `loadGameState(filename)` - Uses `get_compressed()` and `G:start_run()` to restore state
  - `listGameStates()` - Scans profile directory for `.jkr` files

- **Console command** (`debugplus/console.lua`):
  - Input validation (alphanumeric, dash, underscore only)
  - User-friendly error messages
  - Displays absolute paths for saved/loaded files

### Path Handling

The implementation supports two path modes:
1. **Simple filenames** (e.g., `save1`) - Stored in profile directory
2. **Relative paths** (e.g., `Mods/MyMod/fixtures/test`) - Allows mods to bundle test fixtures

### File Format

Uses Balatro's native `.jkr` format (compressed save files), ensuring full compatibility with:
- Manual save file management
- Game's built-in save/load system
- Future game updates

## Testing

To test this feature:

1. Start a run in Balatro
2. Open the console (press `/`)
3. Save your current state: `gamestate save test1`
4. Make some changes (play a few hands, buy something)
5. Load your saved state: `gamestate load test1`
6. Verify you're back to the saved state
7. List all states: `gamestate list`

## Notes

- Game state names can only contain letters, numbers, dashes, and underscores
- The command provides clear error messages for invalid operations
- Absolute file paths are shown in success messages for easy file system access